### PR TITLE
Fix test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@babel/core": "^7.14.3",
     "@babel/eslint-parser": "^7.14.3",
     "@hapi/code": "8.x.x",
-    "@hapi/eslint-plugin": "file:.",
     "@hapi/lab": "^24.0.0",
     "eslint": "^7.5.0"
   },


### PR DESCRIPTION
Running locally I would get test failures because it appeared there were no lines to cover.  This was introduced [somewhere in lab 24.3.0](https://github.com/hapijs/lab/compare/v24.2.1...v24.3.0) . This patch fixes the issue for me, although I could use a hand understanding why it was necessary to begin with, as I don't want to subtly break anything.  @kanongil I traced it back to some changes you made in https://github.com/hapijs/eslint-plugin/pull/20— any ideas?