### PR TITLE
Lazy load module config

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,6 @@ const ForLoop = require('./rules/for-loop');
 const NoArrowception = require('./rules/no-arrowception');
 const NoVar = require('./rules/no-var');
 const Recommended = require('./configs/recommended');
-const Module = require('./configs/module');
 const ScopeStart = require('./rules/scope-start');
 
 
@@ -23,6 +22,25 @@ const internals = {
 };
 
 internals.plugin.configs.recommended = Recommended(internals.plugin);
-internals.plugin.configs.module = Module(internals.plugin);
+
+// Lazy load 'module' config to allow other configs to work when @babel/eslint-parser is not available
+
+Object.defineProperty(internals.plugin.configs, 'module', {
+    configurable: true,
+    enumerable: true,
+    get() {
+
+        const Module = require('./configs/module');
+        const value = Module(internals.plugin);
+
+        Object.defineProperty(this, 'module', {
+            configurable: true,
+            enumerable: true,
+            value
+        });
+
+        return value;
+    }
+});
 
 module.exports = internals.plugin;


### PR DESCRIPTION
The `@babel/eslint-parser` module is essentially a hard dependency, since the "module" config with a [`require('@babel/eslint-parser')`](https://github.com/hapijs/eslint-plugin/blob/5470de15f5debdd580ceed5144c4fec7435e6935/lib/configs/module.js#L3) is always loaded.

This is fixed in this PR by deferring the `require()` until it is first accessed. This allows it to work with code bases that use the "recommended" config along with other parsers.